### PR TITLE
Removed onReceivedSslError override

### DIFF
--- a/ASNECore/src/main/java/com/github/gorbin/asne/core/OAuthActivity.java
+++ b/ASNECore/src/main/java/com/github/gorbin/asne/core/OAuthActivity.java
@@ -124,11 +124,6 @@ public class OAuthActivity extends Activity {
             }
 
             @Override
-            public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-                handler.proceed();
-            }
-
-            @Override
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
                 super.onReceivedError(view, errorCode, description, failingUrl);
 


### PR DESCRIPTION
In compliance with Google Play warnings about inherent security vulnerability.
More information here http://stackoverflow.com/questions/35218775/google-play-warning-webviewclient-onreceivedsslerror-handler
